### PR TITLE
store early db migration files

### DIFF
--- a/back-end/db_migration_files/auto_update_rows.sql
+++ b/back-end/db_migration_files/auto_update_rows.sql
@@ -1,0 +1,23 @@
+
+-- will need to be ran again if adding new table with update_at attribute
+-- trigger functionality for updated_at attributes
+create or replace function set_updated_at() returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+do $$
+declare t text;
+begin
+  for t in
+    select table_name
+    from information_schema.columns
+    where table_schema = 'public' and column_name = 'updated_at'
+  loop
+    execute format('drop trigger if exists trg_%I_updated_at on %I;', t, t);
+    execute format('create trigger trg_%I_updated_at before update on %I
+                    for each row execute function set_updated_at();', t, t);
+  end loop;
+end $$;

--- a/back-end/db_migration_files/db_table_schema.sql
+++ b/back-end/db_migration_files/db_table_schema.sql
@@ -1,0 +1,152 @@
+-- Table DDL 
+-- ORGANIZATIONS
+create table if not exists organizations (
+  id            uuid primary key default gen_random_uuid(),
+  name          text not null,
+  logo_url      text,
+  website       text,
+  phone         text,
+  address_line1 text,
+  address_line2 text,
+  city          text,
+  postal_code   text,
+  country       text,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+);
+
+
+-- USER_PROFILES (app-side user record; key = auth.users.id)
+create table if not exists user_profiles (
+  user_id        uuid primary key
+                 references auth.users (id) on delete cascade,
+  full_name      text,
+  email          text,
+  phone          text,
+  avatar_url     text,
+  timezone       text,
+  default_org_id uuid references organizations(id) on delete set null,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now()
+);
+
+
+-- ORGANIZATION_USERS (membership join; powers RLS)
+create table if not exists organization_users (
+  organization_id uuid not null references organizations(id) on delete cascade,
+  user_id         uuid not null references user_profiles(user_id) on delete cascade,
+  role            text not null check (role in ('owner')),
+  primary key (organization_id, user_id)
+);
+
+
+-- INSPECTORS (domain persona; optionally linked to a user)
+create table if not exists inspectors (
+  id                   uuid primary key default gen_random_uuid(),
+  organization_id      uuid not null references organizations(id) on delete cascade,
+  user_id              uuid references user_profiles(user_id) on delete set null,
+  full_name            text not null,
+  email                text unique,
+  phone                text,
+  license_number       text unique,
+  certifications       text[] not null default '{}',
+  signature_image_url  text,
+  timezone             text,
+  bio                  text,
+  active               boolean not null default true,
+  created_at           timestamptz not null default now(),
+  updated_at           timestamptz not null default now()
+);
+
+
+-- PROPERTIES (org-scoped per ERD)
+create table if not exists properties (
+  id              uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references organizations(id) on delete cascade,
+  address_line1   text not null,
+  address_line2   text,
+  unit            text,
+  city            text not null,
+  region          text,
+  postal_code     text,
+  country         text not null,
+  year_built      smallint,
+  dwelling_type   text check (dwelling_type in ('house','townhome','condo','other')),
+  sqft            integer,
+  bedrooms        integer,
+  bathrooms       integer,
+  garage          boolean,
+  notes           text,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+
+-- INSPECTIONS
+create table if not exists inspections (
+  id               uuid primary key default gen_random_uuid(),
+  inspector_id     uuid not null references inspectors(id) on delete restrict,
+  property_id      uuid not null references properties(id) on delete restrict,
+  organization_id  uuid not null references organizations(id) on delete cascade,
+  status           text not null check (status in ('draft','in_progress','ready_for_review','published')),
+  created_at       timestamptz not null default now(),
+  scheduled_for    timestamptz,
+  started_at       timestamptz,
+  completed_at     timestamptz,
+  updated_at       timestamptz not null default now(),
+  summary          text
+);
+
+
+-- INSPECTION_SECTIONS
+create table if not exists inspection_sections (
+  id              uuid primary key default gen_random_uuid(),
+  inspection_id   uuid not null references inspections(id) on delete cascade,
+  section_name    text not null,
+  notes           text,
+  priority_rating smallint check (priority_rating between 0 and 5)
+);
+
+
+-- OBSERVATIONS
+create table if not exists observations (
+  id           uuid primary key default gen_random_uuid(),
+  section_id   uuid not null references inspection_sections(id) on delete cascade,
+  obs_name     text not null,
+  description  text,
+  implication  text,
+  recommendation  text,
+  severity     text check (severity in ('minor','moderate','critical')),
+  status       text check (status in ('open','resolved','defer')),
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+
+
+-- OBSERVATION_MEDIA
+create table if not exists observation_media (
+  media_id        uuid primary key default gen_random_uuid(),
+  observation_id  uuid not null references observations(id) on delete cascade,
+  type            text not null check (type in ('photo','video','audio')),
+  storage_key     text not null,
+  caption         text,
+  transcription   text,
+  annotated_flag  boolean not null default false,
+  created_at      timestamptz not null default now(),
+  is_primary      boolean not null default false,
+  sort_order      integer not null default 0
+);
+
+
+-- REPORTS
+create table if not exists reports (
+  id             uuid primary key default gen_random_uuid(),
+  inspection_id  uuid not null references inspections(id) on delete cascade,
+  version        integer not null,
+  status         text not null check (status in ('draft','published')),
+  pdf_url        text,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now(),
+  unique (inspection_id, version),
+  check (version > 0)
+);

--- a/back-end/db_migration_files/enable_uuid_generation_extension.sql
+++ b/back-end/db_migration_files/enable_uuid_generation_extension.sql
@@ -1,0 +1,3 @@
+--Extensions
+-- UUID generator for gen_random_uuid()
+create extension if not exists pgcrypto;

--- a/back-end/db_migration_files/indexes.sql
+++ b/back-end/db_migration_files/indexes.sql
@@ -1,0 +1,29 @@
+-- Potential indexes to test
+-- DO NOT RUN UNTIL REVIEWED
+
+-- create index if not exists user_profiles_default_org_idx on user_profiles(default_org_id);
+
+-- create index if not exists organization_users_user_idx on organization_users(user_id);
+
+-- create index if not exists inspectors_org_idx on inspectors(organization_id);
+-- create index if not exists inspectors_user_idx on inspectors(user_id);
+
+-- create index if not exists properties_org_idx on properties(organization_id);
+
+-- create index if not exists inspections_org_idx on inspections(organization_id);
+-- create index if not exists inspections_property_idx on inspections(property_id);
+-- create index if not exists inspections_inspector_idx on inspections(inspector_id);
+-- create index if not exists inspections_status_idx on inspections(status);
+-- create index if not exists inspections_scheduled_idx on inspections(scheduled_for);
+
+-- create index if not exists inspection_sections_inspection_idx on inspection_sections(inspection_id);
+
+-- create index if not exists observations_section_idx on observations(section_id);
+-- create index if not exists observations_status_idx on observations(status);
+-- create index if not exists observations_severity_idx on observations(severity);
+-- create index if not exists observation_media_obs_idx on observation_media(observation_id);
+
+-- create index if not exists observation_media_obs_idx on observation_media(observation_id);
+
+-- create index if not exists reports_inspection_idx on reports(inspection_id);
+-- create index if not exists reports_status_idx on reports(status);

--- a/back-end/db_migration_files/inspection_org_consistency_trigger.sql
+++ b/back-end/db_migration_files/inspection_org_consistency_trigger.sql
@@ -1,0 +1,57 @@
+-- Triggers 
+
+-- check_inspection_org_consistency()
+-- Description:
+--   Constraint trigger function that enforces organization consistency for an inspections row.
+--   When an inspection is inserted or updated, it ensures the inspection.organization_id matches
+--   the organization_id of the referenced property and the referenced inspector. If either referenced
+--   row is missing or the three organization IDs are not identical, the function raises an exception,
+--   preventing the change.
+-- Notes:
+--   This provides early validation to avoid cross-organization references (e.g., an inspector from Org A
+--   assigned to a property in Org B). It performs two point lookups per row; acceptable for single-row
+--   operations but consider bulk insert implications.
+-- Example caller:
+--   INSERT INTO inspections (id, organization_id, property_id, inspector_id, date) VALUES ('uuid', 'org-uuid', 'prop-uuid', 'insr-uuid', now());
+create or replace function check_inspection_org_consistency()
+returns trigger
+language plpgsql
+as $$
+declare
+  insp_org uuid;
+  prop_org uuid;
+  insr_org uuid;
+begin
+  select organization_id into prop_org from properties  where id = new.property_id;
+  select organization_id into insr_org from inspectors  where id = new.inspector_id;
+  insp_org := new.organization_id;
+
+  if prop_org is null or insr_org is null then
+    raise exception 'Property or Inspector not found';
+  end if;
+
+  if insp_org <> prop_org or insp_org <> insr_org then
+    raise exception 'Organization mismatch: inspection(%), property(%), inspector(%) must match',
+      insp_org, prop_org, insr_org;
+  end if;
+
+  return new;
+end;
+$$;
+
+-- trg_inspections_org_consistency
+-- Description:
+--   Constraint trigger attached to inspections that executes check_inspection_org_consistency()
+--   BEFORE INSERT OR UPDATE for each row. Declared DEFERRABLE INITIALLY IMMEDIATE so checks run
+--   immediately by default but can be deferred within a transaction if SET CONSTRAINTS is used.
+-- Notes:
+--   A constraint trigger is appropriate for enforcing data integrity. If expecting bulk loads,
+--   consider deferring or batching validation to reduce per-row overhead.
+-- Example caller:
+--   (implicitly fired) INSERT INTO inspections (...) VALUES (...);
+drop trigger if exists trg_inspections_org_consistency on inspections;
+-- Using a BEFORE constraint trigger provides early failure to prevent bad data
+create constraint trigger trg_inspections_org_consistency
+before insert or update on inspections
+deferrable initially immediate
+for each row execute function check_inspection_org_consistency();

--- a/back-end/db_migration_files/org_member_bootstrap.sql
+++ b/back-end/db_migration_files/org_member_bootstrap.sql
@@ -1,0 +1,49 @@
+-- Bootstrap membership / owner ship to organization creator
+
+-- app_create_org(p_name text)
+-- Description:
+--   RPC function to create a new organization and bootstrap membership for the calling user.
+--   **Requires an authenticated caller (auth.uid() must be present). It inserts a row into organizations,
+--   adds the caller as an 'owner' in organization_users, and updates the caller's user_profiles.default_org_id.
+-- Notes / Security:
+--   Implemented with SECURITY DEFINER and search_path = public so it runs with the function owner's privileges.
+--   Public execution was revoked and EXECUTE granted to the authenticated role — this allows callers with a valid
+--   JWT to create organizations while preventing anonymous invocation. Review the function owner and privileges
+--   to avoid privilege escalation risks.
+-- Example caller:
+--   SELECT app_create_org('My New Organization');
+create or replace function app_create_org(p_name text)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_org_id uuid;
+begin
+  if auth.uid() is null then
+    raise exception 'Must be authenticated';
+  end if;
+
+  insert into organizations (name) values (p_name)
+  returning id into v_org_id;
+
+  insert into organization_users (organization_id, user_id, role)
+  values (v_org_id, auth.uid(), 'owner');
+
+  update user_profiles
+  set default_org_id = v_org_id
+  where user_id = auth.uid();
+
+  return v_org_id;
+end;
+$$;
+
+-- Execution privileges for app_create_org
+-- Description:
+--   Revoke all rights on the function from public, then grant EXECUTE to the authenticated role.
+--   This restricts RPC usage to authenticated users only.
+-- Notes:
+--   Keep the function owner account minimal/trusted since SECURITY DEFINER runs with owner privileges.
+revoke all on function app_create_org(text) from public;
+grant execute on function app_create_org(text) to authenticated;

--- a/back-end/db_migration_files/rls_policies.sql
+++ b/back-end/db_migration_files/rls_policies.sql
@@ -1,0 +1,439 @@
+-- Helpers: small functions to simplify policies
+
+-- is_org_member(p_org_id uuid)
+-- Description: Returns true when the current authenticated user is a member of the given organization.
+-- Typical callers: RLS policies that allow read access to org-scoped records (e.g., rows from organizations, properties, inspections).
+-- Example usage: SELECT is_org_member('3fa85f64-5717-4562-b3fc-2c963f66afa6');
+create or replace function is_org_member(p_org_id uuid)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from organization_users ou
+    where ou.organization_id = p_org_id
+      and ou.user_id = auth.uid()
+  );
+$$;
+
+-- is_org_owner(p_org_id uuid)
+-- Description: Returns true when the current authenticated user is an OWNER of the specified organization.
+-- Typical callers: RLS policies that restrict create/update/delete actions to org owners (admin-level operations such as membership changes).
+-- Example usage: SELECT is_org_owner('3fa85f64-5717-4562-b3fc-2c963f66afa6');
+create or replace function is_org_owner(p_org_id uuid)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from organization_users ou
+    where ou.organization_id = p_org_id
+      and ou.user_id = auth.uid()
+      and ou.role = 'owner'
+  );
+$$;
+
+-- Enabling row level security on all tables.
+
+alter table organizations        enable row level security;
+alter table user_profiles        enable row level security;
+alter table organization_users   enable row level security;
+alter table inspectors           enable row level security;
+alter table properties           enable row level security;
+alter table inspections          enable row level security;
+alter table inspection_sections  enable row level security;
+alter table observations         enable row level security;
+alter table observation_media    enable row level security;
+alter table reports              enable row level security;
+
+-- RLS POLICIES to be reviewed before implementation here
+
+-- organization_users table RLS policies (membership join; owners manage membership)
+------------------------------------------------------------------------------------
+
+-- ou_select_self
+-- Description: Allows authenticated users to SELECT organization_users rows that reference their own user_id.
+-- Typical callers: Clients listing their memberships or roles across organizations.
+-- Example caller: SELECT * FROM organization_users WHERE user_id = auth.uid();
+create policy if not exists ou_select_self
+on organization_users
+for select
+to authenticated
+using (user_id = auth.uid());
+
+-- ou_select_owner_org
+-- Description: Allows organization owners to SELECT membership rows for their organization, enabling owner-level inspection of membership.
+-- Notes: This complements ou_select_self so owners can view all members in their org.
+-- Example caller: SELECT * FROM organization_users WHERE organization_id = 'org-uuid' AND is_org_owner(organization_id);
+create policy if not exists ou_select_owner_org
+on organization_users
+for select
+to authenticated
+using (is_org_owner(organization_id));
+
+-- ou_insert_owner
+-- Description: Restricts INSERT into organization_users so only an org owner can add a new membership row for that organization.
+-- Notes: This prevents regular members from granting membership to others.
+-- Example caller: INSERT INTO organization_users (organization_id, user_id, role) VALUES ('org-uuid', 'user-uuid', 'member') -- only succeeds for owner.
+create policy if not exists ou_insert_owner
+on organization_users
+for insert
+to authenticated
+with check (is_org_owner(organization_id));
+
+-- ou_update_owner
+-- Description: Allows only org owners to UPDATE membership rows in their organization and enforces owner check for new values.
+-- Notes: Ensures that membership changes (role updates, etc.) can only be made by owners.
+-- Example caller: UPDATE organization_users SET role='admin' WHERE organization_id='org-uuid' AND user_id='member-uuid';
+create policy if not exists ou_update_owner
+on organization_users
+for update
+to authenticated
+using (is_org_owner(organization_id))
+with check (is_org_owner(organization_id));
+
+-- ou_delete_owner
+-- Description: Allows only org owners to DELETE membership rows in their organization.
+-- Notes: Prevents non-owners from removing other members; consider safeguards to avoid an owner deleting their own last owner row.
+-- Example caller: DELETE FROM organization_users WHERE organization_id='org-uuid' AND user_id='member-uuid';
+create policy if not exists ou_delete_owner
+on organization_users
+for delete
+to authenticated
+using (is_org_owner(organization_id));
+
+
+
+-- organizations table RLS policies (members can see, owners can edit)
+-----------------------------------------------------------------------
+
+-- org_select_member
+-- Description: Lets any organization member SELECT the organization's row (e.g., to show org name and settings).
+-- Notes: This allows typical member-level reads; ensure sensitive fields are handled appropriately (e.g., masked or moved to a separate table with stricter policies).
+-- Example caller: SELECT * FROM organizations WHERE id = 'org-uuid' AND is_org_member(id);
+create policy if not exists org_select_member
+on organizations
+for select
+to authenticated
+using (is_org_member(id));
+
+-- org_update_owner
+-- Description: Restricts UPDATE on organizations to owners only and enforces owner check on the new values.
+-- Notes: Use this for editing org-level settings. Consider requiring additional audit logging for org updates.
+-- Example caller: UPDATE organizations SET name='New Org' WHERE id='org-uuid';
+create policy if not exists org_update_owner
+on organizations
+for update
+to authenticated
+using (is_org_owner(id))
+with check (is_org_owner(id));
+
+
+
+-- user_profiles table RLS policies (each user manages only their own profile)
+------------------------------------------------------------------------------
+
+-- up_select_own
+-- Description: Allows authenticated users to SELECT only their own profile row.
+-- Notes: Relies on auth.uid(); returns no rows for unauthenticated requests. Ensure user_profiles.user_id is indexed.
+-- Example caller: SELECT * FROM user_profiles WHERE user_id = auth.uid();
+create policy if not exists up_select_own
+on user_profiles
+for select
+to authenticated
+using (user_id = auth.uid());
+
+-- up_insert_own
+-- Description: Permits authenticated users to INSERT a profile only when the inserted user_id equals the authenticated user's id.
+-- Notes: Protects against creating profiles for other users. Consider adding a UNIQUE constraint on user_id if not present.
+-- Example caller: INSERT INTO user_profiles (user_id, display_name) VALUES (auth.uid(), 'Alice');
+create policy if not exists up_insert_own
+on user_profiles
+for insert
+to authenticated
+with check (user_id = auth.uid());
+
+-- up_update_own
+-- Description: Allows authenticated users to UPDATE only their own profile rows and ensures updates do not change ownership.
+-- Notes: The USING clause ensures only rows owned by the user are updatable; WITH CHECK prevents changing user_id to another value.
+-- Example caller: UPDATE user_profiles SET display_name = 'New' WHERE user_id = auth.uid();
+create policy if not exists up_update_own
+on user_profiles
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+
+
+-- inspectors table RLS policies (org-scoped)
+---------------------------------------------
+
+-- insp_select_member
+-- Description: Allows members of the inspector's organization to SELECT inspector rows for that organization.
+-- Typical callers: UI listing inspectors available to a member within their org.
+-- Example caller: SELECT * FROM inspectors WHERE organization_id = 'org-uuid' AND is_org_member(organization_id);
+create policy if not exists insp_select_member
+on inspectors
+for select
+to authenticated
+using (is_org_member(organization_id));
+
+-- insp_cud_owner
+-- Description: Grants owners full create/update/delete (ALL) permissions on inspectors for their organization.
+-- Notes: Using FOR ALL is convenient but remember it also affects SELECT unless other policies restrict SELECT separately.
+-- Example caller: INSERT INTO inspectors (organization_id, name) VALUES ('org-uuid','Inspector A');
+create policy if not exists insp_cud_owner
+on inspectors
+for all
+to authenticated
+using (is_org_owner(organization_id))
+with check (is_org_owner(organization_id));
+
+
+
+-- properties table RLS policies (org-scoped, per ERD)
+------------------------------------------------------
+
+-- props_select_member
+-- Description: Allows organization members to SELECT property records belonging to their organization.
+-- Typical callers: Listing properties in the org dashboard for members.
+-- Example caller: SELECT * FROM properties WHERE organization_id = 'org-uuid';
+create policy if not exists props_select_member
+on properties
+for select
+to authenticated
+using (is_org_member(organization_id));
+
+-- props_cud_owner
+-- Description: Restricts create/update/delete on properties to org owners only.
+-- Notes: Use WITH CHECK to validate new/updated rows still belong to the owner organization.
+-- Example caller: DELETE FROM properties WHERE id = 'property-uuid';
+create policy if not exists props_cud_owner
+on properties
+for all
+to authenticated
+using (is_org_owner(organization_id))
+with check (is_org_owner(organization_id));
+
+
+
+-- inspections table RLS policies (direct org_id, so cheap checks)
+------------------------------------------------------------------
+
+-- inspn_select_member
+-- Description: Lets organization members SELECT inspections that belong to their organization.
+-- Notes: Because inspections contain the organization_id directly, this policy checks are inexpensive.
+-- Example caller: SELECT * FROM inspections WHERE organization_id = 'org-uuid';
+create policy if not exists inspn_select_member
+on inspections
+for select
+to authenticated
+using (is_org_member(organization_id));
+
+-- inspn_cud_owner
+-- Description: Restricts creation/updates/deletes on inspections to organization owners only.
+-- Notes: Consider adding audit fields (created_by, updated_by) and ensuring they are populated correctly at insert/update time.
+-- Example caller: INSERT INTO inspections (organization_id, date) VALUES ('org-uuid', now());
+create policy if not exists inspn_cud_owner
+on inspections
+for all
+to authenticated
+using (is_org_owner(organization_id))
+with check (is_org_owner(organization_id));
+
+
+
+-- inspection_sections table RLS policies (via inspections -> organization_id)
+------------------------------------------------------------------------------
+
+-- sect_select_member
+-- Description: Allows members to SELECT inspection_sections only when the parent inspection belongs to an organization the user is a member of.
+-- Notes: This uses a correlated EXISTS with inspections; ensure inspections.id is indexed for performance.
+-- Example caller: SELECT * FROM inspection_sections WHERE inspection_id = 'inspection-uuid';
+create policy if not exists sect_select_member
+on inspection_sections
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from inspections i
+    where i.id = inspection_sections.inspection_id
+      and is_org_member(i.organization_id)
+  )
+);
+
+-- sect_cud_owner
+-- Description: Grants owners full permissions on inspection_sections, but only when the parent inspection belongs to their organization.
+-- Notes: Both USING and WITH CHECK reference the parent inspection; ensure referential integrity to avoid orphaned sections.
+-- Example caller: INSERT INTO inspection_sections (inspection_id, title) VALUES ('inspection-uuid','Section A');
+create policy if not exists sect_cud_owner
+on inspection_sections
+for all
+to authenticated
+using (
+  exists (
+    select 1
+    from inspections i
+    where i.id = inspection_sections.inspection_id
+      and is_org_owner(i.organization_id)
+  )
+)
+with check (
+  exists (
+    select 1
+    from inspections i
+    where i.id = inspection_sections.inspection_id
+      and is_org_owner(i.organization_id)
+  )
+);
+
+
+
+-- observations table RLS policies (via sections -> inspections -> organization_id)
+-----------------------------------------------------------------------------------
+
+-- obs_select_member
+-- Description: Allows members to SELECT observations when the observation's section belongs to an inspection in their organization.
+-- Notes: The policy does a join from observation -> section -> inspection; index observations.section_id and inspection_sections.inspection_id for best performance.
+-- Example caller: SELECT * FROM observations WHERE section_id = 'section-uuid';
+create policy if not exists obs_select_member
+on observations
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from inspection_sections s
+    join inspections i on i.id = s.inspection_id
+    where s.id = observations.section_id
+      and is_org_member(i.organization_id)
+  )
+);
+
+-- obs_cud_owner
+-- Description: Restricts create/update/delete of observations to org owners, validated against the observation's parent inspection.
+-- Notes: Ensure clients supply valid section_id values; consider adding triggers or foreign key constraints to guarantee referential integrity.
+-- Example caller: UPDATE observations SET note='Updated' WHERE id='obs-uuid';
+create policy if not exists obs_cud_owner
+on observations
+for all
+to authenticated
+using (
+  exists (
+    select 1
+    from inspection_sections s
+    join inspections i on i.id = s.inspection_id
+    where s.id = observations.section_id
+      and is_org_owner(i.organization_id)
+  )
+)
+with check (
+  exists (
+    select 1
+    from inspection_sections s
+    join inspections i on i.id = s.inspection_id
+    where s.id = observations.section_id
+      and is_org_owner(i.organization_id)
+  )
+);
+
+
+
+-- observation_media table RLS policies (via observations -> sections -> inspections -> organization_id)
+--------------------------------------------------------------------------------------------------------
+
+-- media_select_member
+-- Description: Allows members to SELECT observation media when the media is attached to an observation within their organization.
+-- Notes: This policy joins observations -> sections -> inspections; ensure media table references observation_id and that those columns are indexed.
+-- Example caller: SELECT * FROM observation_media WHERE observation_id = 'obs-uuid';
+create policy if not exists media_select_member
+on observation_media
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from observations o
+    join inspection_sections s on s.id = o.section_id
+    join inspections i on i.id = s.inspection_id
+    where o.id = observation_media.observation_id
+      and is_org_member(i.organization_id)
+  )
+);
+
+-- media_cud_owner
+-- Description: Restricts create/update/delete of observation_media to org owners based on the parent inspection's organization.
+-- Notes: For performance, index observations.id, inspection_sections.id, and inspections.id; validate file storage ACLs separately (e.g., Supabase Storage policies).
+-- Example caller: INSERT INTO observation_media (observation_id, url) VALUES ('obs-uuid','https://...') ;
+create policy if not exists media_cud_owner
+on observation_media
+for all
+to authenticated
+using (
+  exists (
+    select 1
+    from observations o
+    join inspection_sections s on s.id = o.section_id
+    join inspections i on i.id = s.inspection_id
+    where o.id = observation_media.observation_id
+      and is_org_owner(i.organization_id)
+  )
+)
+with check (
+  exists (
+    select 1
+    from observations o
+    join inspection_sections s on s.id = o.section_id
+    join inspections i on i.id = s.inspection_id
+    where o.id = observation_media.observation_id
+      and is_org_owner(i.organization_id)
+  )
+);
+
+
+
+-- reports table RLS policies (via inspections -> organization_id)
+------------------------------------------------------------------
+
+-- rpt_select_member
+-- Description: Allows members to SELECT reports that belong to inspections within their organization.
+-- Notes: Reports are filtered by the inspection_id foreign key; index reports.inspection_id for efficient checks.
+-- Example caller: SELECT * FROM reports WHERE inspection_id = 'inspection-uuid';
+create policy if not exists rpt_select_member
+on reports
+for select
+to authenticated
+using (
+  exists (
+    select 1 from inspections i
+    where i.id = reports.inspection_id
+      and is_org_member(i.organization_id)
+  )
+);
+
+-- rpt_cud_owner
+-- Description: Restricts create/update/delete of reports to organization owners, validated against the parent inspection's organization.
+-- Notes: Consider whether report content should have additional visibility rules (e.g., auditors vs. members) and document that separately.
+-- Example caller: DELETE FROM reports WHERE id = 'report-uuid';
+create policy if not exists rpt_cud_owner
+on reports
+for all
+to authenticated
+using (
+  exists (
+    select 1 from inspections i
+    where i.id = reports.inspection_id
+      and is_org_owner(i.organization_id)
+  )
+)
+with check (
+  exists (
+    select 1 from inspections i
+    where i.id = reports.inspection_id
+      and is_org_owner(i.organization_id)
+  )
+);


### PR DESCRIPTION
Pushing db migration files that we have stored as shared queries on Supabase.

auto_update_rows.sql - trigger for auto updating updated_at when row is updated

db_table_schema.sql - current db schema DDL

enable_uuid_generation_extension.sql -  enables generator for uuid

indexes.sql - indexes to test for optimizing performance down the line (way down the line lol)

inspection_org_consistency_trigger.sql - trigger for enforcing inspection row consistency

org_member_bootstrap.sql - RPC function that creates a new organization and bootstraps the calling user as its owner. (for when we want to set up sign up and org creation)

rls_policies.sql - Row level security policies